### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/FlorinWorkshop/fc0f6f75-4589-4a5d-ac63-9d579ee35bf2/06130ad4-b1e3-43f3-8ea5-be1281daddb7/_apis/work/boardbadge/a2fa0bbd-27dd-49d8-8b96-f890fcae022c)](https://dev.azure.com/FlorinWorkshop/fc0f6f75-4589-4a5d-ac63-9d579ee35bf2/_boards/board/t/06130ad4-b1e3-43f3-8ea5-be1281daddb7/Microsoft.RequirementCategory)
 # CodeToCloud with GitHub and Azure DevOps Workshop - Source
 This repository contains the source code for the CodeToCloud workshop. Please follow the instructions in the [CodeToCloud-Student](https://github.com/XpiritBV/CodeToCloud-Student) repository to use this.
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#5](https://dev.azure.com/FlorinWorkshop/fc0f6f75-4589-4a5d-ac63-9d579ee35bf2/_workitems/edit/5). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.